### PR TITLE
fix: PreCompact calls SessionExtract (closes #3)

### DIFF
--- a/hooks/PreCompact.hook.sh
+++ b/hooks/PreCompact.hook.sh
@@ -3,7 +3,7 @@
 # PreCompact.hook.sh — Fires before Claude compacts conversation context
 #
 # Two actions:
-# 1. Trigger FabricExtract on current session (preserves context about to be lost)
+# 1. Trigger SessionExtract on current session (preserves context about to be lost)
 # 2. Git checkpoint all JSONL files (raw transcript backup)
 #
 # This is the "last chance" to capture full context before compaction
@@ -26,11 +26,11 @@ if [ -z "$CWD" ]; then
     CWD="$(pwd)"
 fi
 
-# 1. Trigger extraction via FabricExtract (background, non-blocking)
-HOOK_PATH="$HOME/.claude/hooks/FabricExtract.hook.ts"
+# 1. Trigger extraction via SessionExtract (background, non-blocking)
+HOOK_PATH="$HOME/.claude/hooks/SessionExtract.hook.ts"
 if [ -f "$HOOK_PATH" ]; then
     echo "$INPUT" | bun run "$HOOK_PATH" &
-    log "Triggered FabricExtract"
+    log "Triggered SessionExtract"
 fi
 
 # 2. Git checkpoint the conversation backup repo (if it exists)

--- a/templates/CLAUDE.md.memory
+++ b/templates/CLAUDE.md.memory
@@ -18,7 +18,7 @@ git log --grep="keyword"                    # Commit history
 
 Memory database: `~/.claude/memory.db` (SQLite + FTS5)
 Memory flat files: `~/.claude/MEMORY/` (HOT_RECALL, DISTILLED, DECISIONS, ERRORS, etc.)
-Extraction: automatic at session end via FabricExtract hook
+Extraction: automatic at session end via SessionExtract hook
 
 ### Personality
 Your personality is defined in `~/.claude/MEMORY/PERSONALITY.md`. Read this file and follow it consistently. It defines your communication style, humor level, formality, and unique traits. Your human defined these specifically for you.


### PR DESCRIPTION
## Summary

- `hooks/PreCompact.hook.sh` pointed at `FabricExtract.hook.ts`, which was renamed to `SessionExtract.hook.ts` in 4.1 (see `CHANGELOG.md:12,81`).
- The `[ -f "$HOOK_PATH" ]` guard silently swallowed the missing file, so the pre-compaction extraction branch has been dead code since the rename — only the git-checkpoint branch was running.
- Updated the hook plus the parallel stale reference in `templates/CLAUDE.md.memory`.

## Scope

Two-file diff, rename-only. No behavior change beyond "the thing that was supposed to run now runs."

## Test plan

- [x] `grep -r FabricExtract hooks/ templates/` returns nothing
- [x] `tests/system-test.sh` TEST 253 ("SessionExtract not FabricExtract wired on Stop") still passes — it checks `settings.json`, which this PR does not touch
- [ ] Manual: trigger `/compact` in a real session and confirm `[$TS] PRECOMPACT: Triggered SessionExtract` appears in `~/.claude/MEMORY/EXTRACT_LOG.txt` and that new rows land in `memory.db`

## Credit

Reported by @CanisHelix in #3. Thank you for catching this — the `-f` guard is exactly the kind of thing that hides a rename miss for weeks.

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)
