### PR TITLE
fix: add errors table to mem-cli schema (closes #4)

### DIFF
--- a/mem-cli/src/db/schema.ts
+++ b/mem-cli/src/db/schema.ts
@@ -55,6 +55,18 @@ CREATE TABLE IF NOT EXISTS learnings (
   FOREIGN KEY (session_id) REFERENCES sessions(session_id)
 );
 
+-- Errors table: error/fix pairs with frequency counter for dedup
+-- Written by SessionExtract.hook.ts, read by AssociativeRecall + MCP
+CREATE TABLE IF NOT EXISTS errors (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  error TEXT NOT NULL,
+  cause TEXT,
+  fix TEXT,
+  frequency INTEGER DEFAULT 1,
+  last_seen DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Breadcrumbs table: context, notes, references
 CREATE TABLE IF NOT EXISTS breadcrumbs (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -143,6 +155,10 @@ CREATE INDEX IF NOT EXISTS idx_learnings_project ON learnings(project);
 CREATE INDEX IF NOT EXISTS idx_learnings_category ON learnings(category);
 CREATE INDEX IF NOT EXISTS idx_learnings_created ON learnings(created_at);
 
+-- Error indexes
+CREATE INDEX IF NOT EXISTS idx_errors_error ON errors(error);
+CREATE INDEX IF NOT EXISTS idx_errors_last_seen ON errors(last_seen);
+
 -- Breadcrumb indexes
 CREATE INDEX IF NOT EXISTS idx_breadcrumbs_project ON breadcrumbs(project);
 CREATE INDEX IF NOT EXISTS idx_breadcrumbs_importance ON breadcrumbs(importance);
@@ -188,6 +204,15 @@ CREATE VIRTUAL TABLE IF NOT EXISTS learnings_fts USING fts5(
   tags,
   project,
   content='learnings',
+  content_rowid='id'
+);
+
+-- FTS5 virtual table for errors
+CREATE VIRTUAL TABLE IF NOT EXISTS errors_fts USING fts5(
+  error,
+  fix,
+  cause,
+  content='errors',
   content_rowid='id'
 );
 
@@ -269,6 +294,18 @@ END;
 CREATE TRIGGER IF NOT EXISTS learnings_au AFTER UPDATE ON learnings BEGIN
   INSERT INTO learnings_fts(learnings_fts, rowid, problem, solution, tags, project) VALUES('delete', old.id, old.problem, old.solution, old.tags, old.project);
   INSERT INTO learnings_fts(rowid, problem, solution, tags, project) VALUES (new.id, new.problem, new.solution, new.tags, new.project);
+END;
+
+-- Errors FTS triggers
+CREATE TRIGGER IF NOT EXISTS errors_ai AFTER INSERT ON errors BEGIN
+  INSERT INTO errors_fts(rowid, error, fix, cause) VALUES (new.id, new.error, new.fix, new.cause);
+END;
+CREATE TRIGGER IF NOT EXISTS errors_ad AFTER DELETE ON errors BEGIN
+  INSERT INTO errors_fts(errors_fts, rowid, error, fix, cause) VALUES('delete', old.id, old.error, old.fix, old.cause);
+END;
+CREATE TRIGGER IF NOT EXISTS errors_au AFTER UPDATE ON errors BEGIN
+  INSERT INTO errors_fts(errors_fts, rowid, error, fix, cause) VALUES('delete', old.id, old.error, old.fix, old.cause);
+  INSERT INTO errors_fts(rowid, error, fix, cause) VALUES (new.id, new.error, new.fix, new.cause);
 END;
 
 -- Breadcrumbs FTS triggers


### PR DESCRIPTION
## Summary

- Adds `errors` table + `errors_fts` FTS5 virtual table + insert/update/delete triggers + indexes to `mem-cli/src/db/schema.ts`.
- Fixes `mem catchup` (and `SessionExtract` on `Stop`, and `AssociativeRecall`, and `mcp__memory_search`) for users who initialized their DB via `mem init` — which, per `README.md:716`, is the documented install path.

## Root cause

Two divergent init paths:

- **`./install`** creates `errors` + `errors_fts` + triggers inline (install:117-147).
- **`mem init`** (calls `mem-cli/src/db/schema.ts`) did **not** create any of them.

But the runtime always expects the table:

| Consumer | Operation | Line |
|---|---|---|
| `SessionExtract.hook.ts` | `INSERT INTO errors` | 651 |
| `SessionExtract.hook.ts` | `UPDATE errors SET frequency=…` | 648 |
| `SessionExtract.hook.ts` | `SELECT … FROM errors WHERE error=?` | 646 |
| `AssociativeRecall.hook.ts` | `FROM errors_fts JOIN errors e` | 132-134 |
| `mcp/mem-mcp-server.ts` | `FROM errors_fts JOIN errors e` | 78-82 |
| `mcp/mem-mcp-server.ts` | `SELECT COUNT(*) FROM errors` | 133 |

So anyone who followed the README runbook (Step 7 → `mem init`) and then hit the memory-catchup timer (or Stop hook) got `SqliteError: no such table: errors`, catchup failed silently, extractions queued up forever.

## Verification

```bash
cd mem-cli && bun install
MEM_DB_PATH=/tmp/t.db bun run src/index.ts init
sqlite3 /tmp/t.db ".schema errors"        # table present
sqlite3 /tmp/t.db ".schema errors_fts"    # external-content FTS5
sqlite3 /tmp/t.db "INSERT INTO errors (error, fix) VALUES ('x alpha', 'y beta');
                   SELECT rowid, error, fix FROM errors_fts WHERE errors_fts MATCH 'alpha';"
# → 1|x alpha|y beta    (trigger fires, FTS indexed)

# Idempotency:
MEM_DB_PATH=/tmp/t.db bun run src/index.ts init
# → "✓ Database already exists … (schema updated)" — existing row preserved
```

## Upgrade path for existing broken users

Just re-run `mem init` against the existing DB. `CREATE … IF NOT EXISTS` covers every new piece. No data migration required.

## Known follow-up (deliberately out of scope for this PR)

The broader divergence between `./install` inline schema and `mem-cli/src/db/schema.ts` isn't fully resolved here. Specifically:

- `./install` is still missing `breadcrumbs`, `telos`, `documents` tables (schema.ts has them).
- FTS5 styles differ: install uses non-external-content with `tokenize='porter'`; schema.ts uses `content='<table>'` external-content mode with the default tokenizer.
- Install triggers are named `<table>_fts_insert` / `_fts_delete`; schema.ts names them `<table>_ai` / `_ad` / `_au`.

For users who installed via `./install` and *then* run `mem init` to pick up this fix, the `IF NOT EXISTS` guards will no-op on the existing errors table + FTS, leaving install's shape — but the schema.ts triggers (`errors_ai/ad/au`) will be added alongside install's (`errors_fts_insert/delete`), which means **double FTS writes** on INSERT and DELETE until the two init paths are unified.

The right unify fix is to replace the inline `bun -e "…"` schema block in `install` with a call to `mem init` after Step 6 builds the CLI. That's a bigger PR and deserves its own review thread — I can open it next if you want, but kept this one surgical.

## Test plan

- [x] `bun build mem-cli/src/index.ts` succeeds
- [x] `mem init` on a fresh db creates the errors table, FTS, triggers, indexes
- [x] FTS trigger fires on INSERT (verified via `errors_fts MATCH`)
- [x] `mem init` on an existing db is idempotent
- [ ] On a real host: `systemctl --user start memory-catchup.service && journalctl --user -u memory-catchup.service --since=-1m` shows no "no such table" errors
- [ ] `tests/system-test.sh` — it already asserts `errors_fts` trigger behavior; should pass on pure `mem init` path which previously would have failed at install time

## Credit

Found and reported by @CanisHelix in #4, with a sharp diagnosis: "They diverge considerably and it's unclear as to which is correct or if a hybrid mismanagement is needed." Exactly right on the divergence — thank you.

Fixes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
