### PR TITLE
feat: recall quality floor + widened ack detection

### DIFF
--- a/hooks/AssociativeRecall.hook.ts
+++ b/hooks/AssociativeRecall.hook.ts
@@ -20,6 +20,12 @@ const DB_PATH = join(process.env.HOME!, ".claude", "memory.db");
 const MIN_QUERY_LENGTH = 12; // Skip very short messages like "yes", "ok", "do it"
 const MAX_RESULTS = 5;
 const MAX_OUTPUT_CHARS = 1800;
+// Noise floor: suppress recall results scoring below this. Tuned from live
+// diagnostic data — clearly-garbage matches cluster at 0.15–1.8; useful
+// matches at 2.5+. Showing weak matches adds cognitive tax and can mislead,
+// so silence is better than noise. Raise for stricter recall, lower for
+// broader; 2.0 is the conservative default.
+const MIN_SCORE = 2.0;
 
 // Words that are too common to search for
 const STOP_WORDS = new Set([
@@ -203,9 +209,9 @@ function searchMemory(terms: string[]): RecallResult[] {
 
   db.close();
 
-  // Sort by score descending, take top N
+  // Sort by score descending, apply noise floor, take top N
   results.sort((a, b) => b.score - a.score);
-  return results.slice(0, MAX_RESULTS);
+  return results.filter((r) => r.score >= MIN_SCORE).slice(0, MAX_RESULTS);
 }
 
 function formatResults(results: RecallResult[]): string {
@@ -241,7 +247,10 @@ async function main() {
 
   // Skip if it looks like a rating or simple acknowledgment
   if (/^\d{1,2}$/.test(content.trim())) return;
-  if (/^(yes|no|ok|sure|thanks|do it|go|continue|proceed)\b/i.test(content.trim())) return;
+  // Widened to cover more short-form acks and short-signal directives —
+  // recall on "do your X" / "run it" / "try that" is essentially searching
+  // on ~no signal and reliably returns noise. Silence beats noise here.
+  if (/^(yes|yep|yeah|no|nope|ok|okay|sure|thanks|thx|do it|do your|go|run it|try (it|that)|fix it|make it|apply|continue|proceed|right|correct|agreed?|ship it|lgtm|good|great|perfect)\b/i.test(content.trim())) return;
 
   const terms = extractKeyTerms(content);
   if (terms.length === 0) return;


### PR DESCRIPTION
## Summary

Two small, complementary changes to `hooks/AssociativeRecall.hook.ts`:

1. **Noise floor** — new `MIN_SCORE = 2.0` filter before the top-N slice. Previously, recalls scoring as low as 0.15–1.8 were injected into `[MEMORY CONTEXT]`; those are now suppressed.
2. **Widened ack/short-directive regex** — now catches `yep/yeah/nope/okay/thx`, `do your X`, `run it`, `try that`, `fix it`, `make it`, `apply`, `right`, `correct`, `agreed`, `ship it`, `lgtm`, `good`, `great`, `perfect`. These short prompts reliably return noise when searched against memory, so the hook returns silent instead.

**Net effect: silence beats noise.** When recall fires after this change, it is because a strong match exists — not because the filter let through anything.

## Why this exists

Came out of the investigation that @CanisHelix's bug reports in #3 and #4 prompted. While fixing those, instrumenting the hook made the underlying recall-quality problem visible. Representative case from a live diagnostic session:

| User said | Old behavior |
|---|---|
| *"if it is helpful, yes"* | Extracted single term `helpful`, surfaced 5 records scoring 0.15–1.78 — all unrelated |
| *"do your recommended"* | Passed the narrow ack regex, extracted typo `recommded`, found nothing, silently returned (OK) |
| *"is this real benefit or bloat?"* | Generic words produced top match "Relocate API key source from settings.json" — completely unrelated |

With this PR the first case returns silent; the second is unchanged; the third is helped partially (the quality floor suppresses the weakest results).

## Scope

Deliberately minimal. The other half of the recall-quality work — prior-message context blending, IDF-based term ranking, and extraction-template rejection to prevent DB pollution at source — is in the companion PR. Kept separate so this small behavioral change can merge and stand on its own.

## Test plan

- [x] Hook runs in 20–40ms on nixf (budget is 300ms)
- [x] Before/after diff on a representative query set: noise suppressed, strong matches unchanged
- [x] No schema changes, no dependency changes
- [ ] Bake on nixf → recall still feels useful, not over-silenced (will tune `MIN_SCORE` up/down if needed)

## Credit

This PR and its companion would not exist without @CanisHelix's reports in #3 and #4. Reporting "memory catchup fails" and "FabricExtract still needed?" led me into this file, which led to instrumenting the recall layer, which surfaced improvements far beyond the originally reported bugs. Crediting the causal chain — thank you, @CanisHelix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
