### PR TITLE
feat: prior-message blend + IDF term ranking + extract-template rejection

### DIFF
--- a/hooks/AssociativeRecall.hook.ts
+++ b/hooks/AssociativeRecall.hook.ts
@@ -14,12 +14,14 @@
  */
 
 import { Database } from "bun:sqlite";
+import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 
 const DB_PATH = join(process.env.HOME!, ".claude", "memory.db");
 const MIN_QUERY_LENGTH = 12; // Skip very short messages like "yes", "ok", "do it"
 const MAX_RESULTS = 5;
 const MAX_OUTPUT_CHARS = 1800;
+const PRIOR_MESSAGES_TO_INCLUDE = 2; // Read last N user messages for context blending
 // Noise floor: suppress recall results scoring below this. Tuned from live
 // diagnostic data — clearly-garbage matches cluster at 0.15–1.8; useful
 // matches at 2.5+. Showing weak matches adds cognitive tax and can mislead,
@@ -73,6 +75,49 @@ interface RecallResult {
   score: number;
 }
 
+// Read the last N user messages from this session's transcript JSONL.
+// Catches "did that work?" / "do your X" / "run it" type queries that
+// have no signal alone but rich signal when combined with prior turns.
+function getRecentUserMessages(sessionId: string | undefined, count: number): string[] {
+  if (!sessionId) return [];
+  try {
+    const cwd = process.cwd();
+    const encoded = "-" + cwd.replace(/^\/+/, "").replace(/\//g, "-");
+    const transcriptPath = join(process.env.HOME!, ".claude", "projects", encoded, `${sessionId}.jsonl`);
+    if (!existsSync(transcriptPath)) return [];
+
+    const raw = readFileSync(transcriptPath, "utf-8");
+    const lines = raw.split("\n");
+    const tail = lines.slice(-200); // last 200 lines is plenty for ~5 user turns
+    const userTexts: string[] = [];
+    for (let i = tail.length - 1; i >= 0 && userTexts.length < count; i--) {
+      const line = tail[i].trim();
+      if (!line) continue;
+      try {
+        const obj = JSON.parse(line);
+        const msg = obj?.message;
+        if (msg?.role !== "user") continue;
+        let text = "";
+        if (typeof msg.content === "string") {
+          text = msg.content;
+        } else if (Array.isArray(msg.content)) {
+          text = msg.content
+            .filter((b: any) => b && b.type === "text")
+            .map((b: any) => b.text || "")
+            .join(" ");
+        }
+        // Strip system-reminder blocks and very short ack-style messages
+        text = text.replace(/<system-reminder>[\s\S]*?<\/system-reminder>/g, "").trim();
+        if (text.length < MIN_QUERY_LENGTH) continue;
+        userTexts.unshift(text); // chronological order
+      } catch { /* skip malformed line */ }
+    }
+    return userTexts;
+  } catch {
+    return []; // any failure → no prior context, hook still runs on current message alone
+  }
+}
+
 function extractKeyTerms(text: string): string[] {
   // Remove markdown, URLs, code blocks, paths
   const cleaned = text
@@ -84,12 +129,42 @@ function extractKeyTerms(text: string): string[] {
 
   const words = cleaned.split(/\s+/).filter((w) => w.length > 2);
   const terms = words.filter((w) => !STOP_WORDS.has(w));
-
-  // Deduplicate and take top terms (longer words are more likely to be specific)
   const unique = [...new Set(terms)];
-  unique.sort((a, b) => b.length - a.length);
 
-  return unique.slice(0, 6);
+  // Rank by rarity in the memory corpus (IDF proxy). Rarer tokens carry
+  // more topic signal than long-but-common ones. Length is a tiebreaker.
+  // Terms present in zero rows fall back to length — they may be proper
+  // nouns worth keeping even if they miss. DB probe cost: ~1ms per term,
+  // well inside the 300ms hook budget.
+  try {
+    const db = new Database(DB_PATH, { readonly: true });
+    const withScore = unique.map((term) => {
+      let hits = 0;
+      try {
+        const q = `"${term.replace(/"/g, "")}"`;
+        const r1 = db.prepare(`SELECT COUNT(*) AS c FROM loa_fts WHERE loa_fts MATCH ?`).get(q) as any;
+        const r2 = db.prepare(`SELECT COUNT(*) AS c FROM decisions_fts WHERE decisions_fts MATCH ?`).get(q) as any;
+        const r3 = db.prepare(`SELECT COUNT(*) AS c FROM learnings_fts WHERE learnings_fts MATCH ?`).get(q) as any;
+        const r4 = db.prepare(`SELECT COUNT(*) AS c FROM errors_fts WHERE errors_fts MATCH ?`).get(q) as any;
+        hits = (r1?.c ?? 0) + (r2?.c ?? 0) + (r3?.c ?? 0) + (r4?.c ?? 0);
+      } catch { /* unsearchable term → fall back to length */ }
+      return { term, hits, len: term.length };
+    });
+    db.close();
+    // Ascending hits (rare first); zero-hit → infinity so they rank last.
+    // Within equal rarity, longer wins.
+    withScore.sort((a, b) => {
+      const ah = a.hits === 0 ? 1e9 : a.hits;
+      const bh = b.hits === 0 ? 1e9 : b.hits;
+      if (ah !== bh) return ah - bh;
+      return b.len - a.len;
+    });
+    return withScore.slice(0, 6).map((w) => w.term);
+  } catch {
+    // DB unreachable — fall back to length sort
+    unique.sort((a, b) => b.length - a.length);
+    return unique.slice(0, 6);
+  }
 }
 
 function buildFtsQuery(terms: string[]): string {
@@ -241,18 +316,36 @@ async function main() {
   }
 
   const content = input.content || "";
+  const trimmed = content.trim();
 
-  // Skip short messages (greetings, confirmations, ratings)
-  if (content.length < MIN_QUERY_LENGTH) return;
+  // Skip pure numeric ratings — they have zero recall signal on their own
+  // AND zero recall signal when blended with prior context.
+  if (/^\d{1,2}$/.test(trimmed)) return;
 
-  // Skip if it looks like a rating or simple acknowledgment
-  if (/^\d{1,2}$/.test(content.trim())) return;
-  // Widened to cover more short-form acks and short-signal directives —
-  // recall on "do your X" / "run it" / "try that" is essentially searching
-  // on ~no signal and reliably returns noise. Silence beats noise here.
-  if (/^(yes|yep|yeah|no|nope|ok|okay|sure|thanks|thx|do it|do your|go|run it|try (it|that)|fix it|make it|apply|continue|proceed|right|correct|agreed?|ship it|lgtm|good|great|perfect)\b/i.test(content.trim())) return;
+  // Classify the current prompt. Short / ack / low-signal prompts get
+  // blended with prior user turns so recall anchors on the conversation
+  // topic, not on the single tiny current message.
+  const isShort = content.length < MIN_QUERY_LENGTH;
+  const isAck = /^(yes|yep|yeah|no|nope|ok|okay|sure|thanks|thx|do it|do your|go|run it|try (it|that)|fix it|make it|apply|continue|proceed|right|correct|agreed?|ship it|lgtm|good|great|perfect)\b/i.test(trimmed);
+  const wordCount = trimmed.split(/\s+/).filter(Boolean).length;
+  const looksLikeAck = wordCount <= 4 || extractKeyTerms(content).length < 3;
 
-  const terms = extractKeyTerms(content);
+  let queryText = content;
+  if (isShort || isAck || looksLikeAck) {
+    // Low-signal current turn — blend in prior context or skip entirely.
+    const prior = getRecentUserMessages(input.session_id, PRIOR_MESSAGES_TO_INCLUDE);
+    if (prior.length === 0) return; // no prior → preserve old skip behavior
+    queryText = prior.join(" ") + " " + content;
+  } else {
+    // Substantive turn — still blend the immediately-prior user turn so
+    // recall reflects the conversational arc, not just this one sentence.
+    const prior = getRecentUserMessages(input.session_id, 1);
+    if (prior.length > 0 && prior[0] !== content) {
+      queryText = prior[0] + " " + content;
+    }
+  }
+
+  const terms = extractKeyTerms(queryText);
   if (terms.length === 0) return;
 
   const results = searchMemory(terms);

--- a/hooks/SessionExtract.hook.ts
+++ b/hooks/SessionExtract.hook.ts
@@ -592,6 +592,24 @@ async function extractAndAppend(conversationPath: string, cwd: string): Promise<
 
 const DB_PATH = join(process.env.HOME!, '.claude', 'memory.db');
 
+// Reject values that are clearly extraction-template leaks — the LLM
+// returned the prompt's placeholder text instead of actual content.
+// These pollute the DB and can never be useful in recall. Returns the
+// original string if clean, or null if it's a placeholder to be rejected.
+// Conservative: only matches bracket-wrapped strings with known template
+// vocabulary. Real bracketed content (e.g. `[42]`, `[error code 137]`) passes.
+function rejectPlaceholder(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const t = value.trim();
+  if (!t || t.length < 2) return null;
+  if (/^\[.*\]$/.test(t)) {
+    if (/error\s*(message|pattern)|what\s+fixed|important\s+decision|description\s+of|no\s+specific|the\s+underlying\s+cause|your\s+(description|answer|response)|placeholder|fill\s+in|what\s+(happened|went\s+wrong)|missing\s+\w+\s+inputs|investigate\s+and\s+fix/i.test(t)) {
+      return null;
+    }
+  }
+  return value;
+}
+
 function writeToDb(extracted: string, project: string, date: string, sessionId: string, title: string): void {
   // Only write if DB exists (mem init has been run)
   if (!existsSync(DB_PATH)) return;
@@ -617,8 +635,9 @@ function writeToDb(extracted: string, project: string, date: string, sessionId: 
 
     for (const line of lines) {
       const parts = line.split(':');
-      const decision = parts[0].trim();
-      const reasoning = parts.length > 1 ? parts.slice(1).join(':').trim() : null;
+      const decision = rejectPlaceholder(parts[0].trim());
+      if (!decision) continue; // primary placeholder — no value in storing
+      const reasoning = parts.length > 1 ? rejectPlaceholder(parts.slice(1).join(':').trim()) : null;
 
       const r = db.prepare(
         `INSERT INTO decisions (created_at, session_id, project, decision, reasoning) VALUES (?, ?, ?, ?, ?)`
@@ -639,8 +658,11 @@ function writeToDb(extracted: string, project: string, date: string, sessionId: 
     for (const line of lines) {
       const colonIdx = line.indexOf(':');
       if (colonIdx > 0) {
-        const error = line.slice(0, colonIdx).trim();
-        const fix = line.slice(colonIdx + 1).trim();
+        const error = rejectPlaceholder(line.slice(0, colonIdx).trim());
+        if (!error) continue; // primary placeholder — skip
+        // Null out placeholder fixes so AssociativeRecall's `if (!r.fix)` skips
+        // the row during recall (the error pattern itself may still be useful).
+        const fix = rejectPlaceholder(line.slice(colonIdx + 1).trim());
 
         // Upsert: increment frequency if error exists, else insert
         const existing = db.prepare('SELECT id, frequency FROM errors WHERE error = ?').get(error) as any;


### PR DESCRIPTION
## Summary

Three coordinated changes across two files that turn `AssociativeRecall` from a noise-prone keyword skimmer into a topic-anchored retrieval layer — and prevent `SessionExtract` from ever polluting the DB with the template text it would suppress at query time.

### 1. Prior-message context blending (`AssociativeRecall.hook.ts`)

New `getRecentUserMessages()` reads the session's transcript JSONL and pulls the last N user turns.

- **Short / ack / ≤4-word / low-signal prompts** now blend 2 prior user turns before FTS-searching. Previously these either returned silent (PR #7) or produced single-term garbage matches.
- **Substantive prompts** blend 1 prior turn so recall reflects conversational arc.
- Falls back to skip if no prior turns exist.

### 2. IDF-based term ranking (`AssociativeRecall.hook.ts`)

`extractKeyTerms` previously sorted by length as a weak specificity proxy. Problem: typos and long-but-common words outranked short-but-rare domain terms. Now each candidate term gets one FTS probe across the four searched tables; results sort **ascending by corpus hit count** (rarer first), with length as tiebreaker. Zero-hit terms fall back to length (proper nouns worth keeping even if they miss today).

Latency cost: ~1ms per term, ~6ms per call, well inside the 300ms budget.

### 3. Extract-template rejection (`SessionExtract.hook.ts`)

New `rejectPlaceholder()` helper applied before `INSERT`/`UPDATE` to both decisions and errors. Drops rows whose primary field is a bracket-wrapped template fragment like:

```
[Error message or pattern]
[Important decision and why]
[what fixed it]
[Investigate and fix the root cause]
[Description of the error]
```

For secondary fields (reasoning, fix), the helper nulls them instead of skipping the entire row — so the primary content survives and `AssociativeRecall`'s existing `if (!r.fix) continue` guard naturally hides the empty half at recall time.

## Why this exists

Live instrumentation on a real host (655 embedded records, 3 months of memory) showed `AssociativeRecall` surfacing near-random low-score noise on almost every short user turn. The companion PR (#7, merged) added a quality floor and widened ack detection — the floor catches obvious garbage, but it doesn't help with:

- **Zero-signal prompts** ("do your recommended", "run it") that still need to produce useful recall.
- **Weak FTS ranking** where 5 OR-joined terms flatten specificity.
- **Ongoing DB pollution** from template leaks in the extraction prompt responses.

This PR addresses all three.

## Observed pollution (what the rejection catches)

On the host where we ran the live investigation, the DB had accumulated:
- 12 `errors` rows with pure bracket-template content in the `error` column
- 9 more `errors` rows with placeholder `fix` text on a real error
- 1 `decisions` row that was literally `[Important decision and why]`

Those rows were polluting every recall that happened to match their generic template vocabulary. Cleaned manually on that host; this PR prevents any public install from accumulating the same junk.

## Test plan

- [x] `AssociativeRecall` runs in 20–40ms (budget 300ms)
- [x] `SessionExtract` builds cleanly (`bun build`)
- [x] Representative query set pre/post on a real DB:
    - "do your recommended" → pre: single-term garbage or silent; post: blends prior turn, pulls topic-relevant recall
    - "is this real benefit or bloat?" → pre: top hit "Relocate API key source"; post: generic terms demoted by IDF, topic signal boosted
    - Substantive LMF4.1 query → unchanged, still returns the relevant prior sessions
- [x] Template rejection tested against exact pollution patterns observed in the wild
- [ ] Bake in use — will tune `PRIOR_MESSAGES_TO_INCLUDE` or the ack-heuristic word count if context-blend drift is observed

## Scope discipline

No schema changes, no dependency changes, no new settings. All three changes are localized to two files. The rejection regex is intentionally conservative: it only matches bracket-wrapped strings with known template vocabulary, so real bracketed content like `[42]` or `[error code 137]` passes through.

## Credit

This PR and its companion #7 would not exist without @CanisHelix's bug reports in #3 and #4. Fixing a stale hook reference and a missing-table issue sent me deep into these files, which surfaced the retrieval-quality problem. The improvements are downstream of that initial push — thank you, @CanisHelix. Crediting the full chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
